### PR TITLE
Configurable base url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ description: |-
 provider "qbee" {
   username = "qbee@example.com"
   password = "test123"
+  base_url = "https://www.app.qbee.io"
 }
 ```
 
@@ -24,6 +25,6 @@ provider "qbee" {
 
 ### Optional
 
-- `password` (String, Sensitive) Qbee password
-- `username` (String) Qbee username
-- `base_url` (String) Base URL for the qbee API. Defaults to `https://www.app.qbee.io`
+- `base_url` (String) Qbee base URL. Defaults to `https://www.app.qbee.io`. Can also be set using the QBEE_BASE_URL environment variable.
+- `password` (String, Sensitive) Qbee password. Can also be set using the QBEE_PASSWORD environment variable.
+- `username` (String) Qbee username. Can also be set using the QBEE_USERNAME environment variable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,4 @@ provider "qbee" {
 
 - `password` (String, Sensitive) Qbee password
 - `username` (String) Qbee username
+- `base_url` (String) Base URL for the qbee API. Defaults to `https://www.app.qbee.io`

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,5 @@
 provider "qbee" {
   username = "qbee@example.com"
   password = "test123"
+  base_url = "https://www.app.qbee.io"
 }


### PR DESCRIPTION
This adds support to configure the baseURL of the qbee client used by the provider, so non-standard qbee deployments can also be targeted by this provider.