### PR TITLE
Only run integration tests in CI for local PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a conditional check to the GitHub Actions workflow for pull request testing. The change ensures that the workflow only runs if the pull request originates from the same repository.

* [`.github/workflows/pr-test.yml`](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eR14): Added an `if` condition to the `test` job to verify that the pull request's source repository matches the target repository (`github.event.pull_request.head.repo.full_name == github.repository`).