### PR TITLE
Allow to trigger tests via workflow_dispatch

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -11,7 +12,6 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The main change is the addition of the `workflow_dispatch` trigger, which allows the workflow to be manually triggered from the GitHub UI.