### PR TITLE
DEV-3002: Mask sensitive attributes

### DIFF
--- a/internal/provider/docker_containers_resource.go
+++ b/internal/provider/docker_containers_resource.go
@@ -114,6 +114,7 @@ func (r *dockerContainersResource) Schema(_ context.Context, _ resource.SchemaRe
 						"password": schema.StringAttribute{
 							Required:    true,
 							Description: "Password for the registry",
+							Sensitive:   true,
 						},
 					},
 				},

--- a/internal/provider/password_resource.go
+++ b/internal/provider/password_resource.go
@@ -69,6 +69,7 @@ func (r *passwordResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						"password_hash": schema.StringAttribute{
 							Required:    true,
 							Description: "The password hash for the user. See https://qbee.io/docs/qbee-password.html for more information.",
+							Sensitive:   true,
 						},
 					},
 				},

--- a/internal/provider/podman_containers_resource.go
+++ b/internal/provider/podman_containers_resource.go
@@ -114,6 +114,7 @@ func (r *podmanContainersResource) Schema(_ context.Context, _ resource.SchemaRe
 						"password": schema.StringAttribute{
 							Required:    true,
 							Description: "Password for the registry",
+							Sensitive:   true,
 						},
 					},
 				},


### PR DESCRIPTION
This pull request improves the security of sensitive data in resource schemas by marking certain password-related fields as sensitive. This ensures that these values are not displayed in logs or UI outputs, reducing the risk of accidental exposure.

Security enhancements:

* Marked the `password` field in the `dockerContainersResource` schema as sensitive.
* Marked the `password` field in the `podmanContainersResource` schema as sensitive.
* Marked the `password_hash` field in the `passwordResource` schema as sensitive.

The issue was reported first by @ttzero25 through our vulnerability disclosure program.